### PR TITLE
The default Apollo Client is now constructed on demand to avoid confu…

### DIFF
--- a/src/clientAtom.ts
+++ b/src/clientAtom.ts
@@ -17,7 +17,7 @@ export const clientAtom = atom(
   (get) => {
     const customClient = get(customClientAtom)
 
-    if (!customClient) {
+    if (customClient) {
       return customClient
     }
 

--- a/src/clientAtom.ts
+++ b/src/clientAtom.ts
@@ -1,13 +1,23 @@
-import { InMemoryCache, ApolloClient } from '@apollo/client'
+import {
+  InMemoryCache,
+  ApolloClient,
+  NormalizedCacheObject,
+} from '@apollo/client'
 import { atom } from 'jotai/vanilla'
 
 const DEFAULT_URL =
   (typeof process === 'object' && process.env.JOTAI_APOLLO_DEFAULT_URL) ||
   '/graphql'
 
-const client = new ApolloClient({
-  uri: DEFAULT_URL,
-  cache: new InMemoryCache(),
-})
+let defaultClient: ApolloClient<NormalizedCacheObject> | null = null
 
-export const clientAtom = atom(client)
+export const clientAtom = atom(() => {
+  if (!defaultClient) {
+    defaultClient = new ApolloClient({
+      uri: DEFAULT_URL,
+      cache: new InMemoryCache(),
+    })
+  }
+
+  return defaultClient
+})

--- a/src/clientAtom.ts
+++ b/src/clientAtom.ts
@@ -11,13 +11,26 @@ const DEFAULT_URL =
 
 let defaultClient: ApolloClient<NormalizedCacheObject> | null = null
 
-export const clientAtom = atom(() => {
-  if (!defaultClient) {
-    defaultClient = new ApolloClient({
-      uri: DEFAULT_URL,
-      cache: new InMemoryCache(),
-    })
-  }
+const customClientAtom = atom<ApolloClient<unknown> | null>(null)
 
-  return defaultClient
-})
+export const clientAtom = atom(
+  (get) => {
+    const customClient = get(customClientAtom)
+
+    if (!customClient) {
+      return customClient
+    }
+
+    if (!defaultClient) {
+      defaultClient = new ApolloClient({
+        uri: DEFAULT_URL,
+        cache: new InMemoryCache(),
+      })
+    }
+
+    return defaultClient
+  },
+  (_get, set, client: ApolloClient<unknown>) => {
+    set(customClientAtom, client)
+  }
+)


### PR DESCRIPTION
…sing the Apollo DevTools.

Me and my team found that by providing our own Apollo Client, the default one was still being created and making the Apollo DevTools think that it was the client it was supposed to track. I implemented the atom in a way that the Apollo Client gets created only when it is used for the first time.